### PR TITLE
Change directObject type in schema from string to object.

### DIFF
--- a/ch02/2.4/hellocalculator/src/test/resources/event_schema.json
+++ b/ch02/2.4/hellocalculator/src/test/resources/event_schema.json
@@ -11,7 +11,7 @@
       "type": "string"
     },
     "directObject": {
-      "type": "string",
+      "type": "object",
       "minProperties": 1
     },
     "context": {


### PR DESCRIPTION
The type specified for directObject in the schema is incorrect, and causes the test to fail.  Changing it to 'object' resolves the test failure.
