### PR TITLE
Make up.guidance more generic; remove instructions to missing ch02 stuff

### DIFF
--- a/vagrant/up.guidance
+++ b/vagrant/up.guidance
@@ -1,4 +1,2 @@
 To get started:
 vagrant ssh
-cd /vagrant/ch02/2.1/hellocalculator
-gradle test


### PR DESCRIPTION
As mentioned at https://github.com/alexanderdean/Unified-Log-Processing/issues/15#issuecomment-180461625